### PR TITLE
Remove node specific code

### DIFF
--- a/src/modulebuilder.js
+++ b/src/modulebuilder.js
@@ -20,7 +20,6 @@
 
 const FunctionBuilder = require("./functionbuilder.js");
 const utils = require("./utils.js");
-const { TextEncoder, TextDecode } = require("util");
 
 class ModuleBuilder {
 
@@ -143,7 +142,7 @@ class ModuleBuilder {
     }
 
     allocString(s) {
-        const encoder = new TextEncoder();
+        const encoder = new globalThis.TextEncoder();
         const uint8array = encoder.encode(s);
         return this.alloc([...uint8array, 0]);
     }

--- a/src/protoboard.js
+++ b/src/protoboard.js
@@ -20,7 +20,6 @@
 /* globals WebAssembly */
 const bigInt = require("big-integer");
 const ModuleBuilder = require("./modulebuilder");
-const assert = require("assert");
 
 function buf2hex(buffer) { // buffer is an ArrayBuffer
     return Array.prototype.map.call(new Uint8Array(buffer), x => ("00" + x.toString(16)).slice(-2)).join("");
@@ -151,7 +150,9 @@ class Protoboard {
                 v = rd.quotient;
                 p += 4;
             }
-            assert(v.isZero());
+            if (!v.isZero()) {
+                throw new Error('Expected v to be 0');
+            }
 /*            this.i32[p>>2] = bigInt(nums[i]).shiftRight( (words-1)*this.bitsPerBytes).toJSNumber();
             p += 4;
 */        }


### PR DESCRIPTION
This removes node specific code from the project.

The `TextEncoder` class has been available on the global object in node since v11 and is always available on the browser global.

The assert library was only being used to throw 1 error.