### PR TITLE
fix: Ensure BigInts are used during BigInt math

### DIFF
--- a/src/protoboard.js
+++ b/src/protoboard.js
@@ -177,7 +177,7 @@ class Protoboard {
                 if (this.bitsPerBytes <32) {
                     if (v&0x80000000) v = v-0x100000000;
                 }
-                acc = acc + v;
+                acc = acc + BigInt(v);
             }
             nums.push(acc);
             pos += words*4;

--- a/test/protoboard.js
+++ b/test/protoboard.js
@@ -45,4 +45,15 @@ describe("Basic protoboard test", () => {
         assert.equal(logs[0], "0000002c: 44");
         assert.equal(logs[1], "0000000000000042: 66");
     });
+
+    it("Can `alloc`, `set`, and `get` data", async() => {
+        const n8q=48;
+
+        const pb = await buildProtoboard(function() {}, n8q);
+
+        const e1 = pb.alloc(n8q*2);
+        const pos = pb.set(e1, 1n);
+
+        assert.equal(pb.get(pos), 1n);
+    });
 });


### PR DESCRIPTION
I made a mistake when updating to native BigInts where we are pulling a value from `protoboard.i32` and the value isn't a BigInt. When we try to add that to a BigInt `acc` the code fails.

I fixed the bug and added a regression test in this PR.