### PR TITLE
fix: Discard the minus sign in bitLength helper

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -30,7 +30,11 @@ export function isZero(n) {
 }
 
 export function bitLength(n) {
-    return n.toString(2).length;
+    if (isNegative(n)) {
+        return n.toString(2).length - 1; // discard the - sign
+    } else {
+        return n.toString(2).length;
+    }
 }
 
 export function u32(n) {


### PR DESCRIPTION
No need to generate extra strings.