### PR TITLE
fix: Wrap operations for correct precedence

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -34,7 +34,11 @@ function isZero(n) {
 }
 
 function bitLength(n) {
-    return n.toString(2).length;
+    if (isNegative(n)) {
+        return n.toString(2).length - 1; // discard the - sign
+    } else {
+        return n.toString(2).length;
+    }
 }
 
 function u32(n) {
@@ -103,7 +107,7 @@ function varint(_n) {
     const bits = bitLength(_n);
     if (_n<0) {
         sign = true;
-        n = 1n << BigInt(bits) + _n;
+        n = (1n << BigInt(bits)) + _n;
     } else {
         sign = false;
         n = toNumber(_n);

--- a/src/utils.js
+++ b/src/utils.js
@@ -117,7 +117,7 @@ export function varint(_n) {
     const bits = bitLength(_n);
     if (_n<0) {
         sign = true;
-        n = 1n << BigInt(bits) + _n;
+        n = (1n << BigInt(bits)) + _n;
     } else {
         sign = false;
         n = toNumber(_n);

--- a/test/protoboard.js
+++ b/test/protoboard.js
@@ -8,6 +8,7 @@ describe("Basic protoboard test", () => {
 
             buildTest1();
             buildTest2();
+            buildTest3();
 
             function buildTest1() {
                 const f = module.addFunction("test1");
@@ -31,7 +32,15 @@ describe("Basic protoboard test", () => {
 
             }
 
+            // Regression test for PR#20
+            function buildTest3() {
+                const f = module.addFunction("test3");
 
+                const c = f.getCodeBuilder();
+                f.addCode(c.call("log32", c.i32_const(-66)));
+
+                module.exportFunction("test3");
+            }
         });
 
         const logs = [];
@@ -41,9 +50,12 @@ describe("Basic protoboard test", () => {
 
         pb.test1();
         pb.test2();
+        pb.test3();
 
         assert.equal(logs[0], "0000002c: 44");
         assert.equal(logs[1], "0000000000000042: 66");
+        // Regression test for PR#20
+        assert.equal(logs[2], "ffffffbe: 4294967230");
     });
 
     it("Can `alloc`, `set`, and `get` data", async() => {


### PR DESCRIPTION
I messed up the operator precedence on `varint` for negative numbers. This fixes the issue and adds a regression test.